### PR TITLE
Fix syntax error in init.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,20 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
   - Oferă opțiunea de urmărire log-uri în timp real
 
 ### Gestionare Container MilDocDMS
-- **5. Dezinstalează MilDocDMS**
-  Elimină containerele, volumele și directorul MilDocDMS (dacă există).
-  Curăță orice resurse Docker rămase chiar dacă folderul a fost șters, inclusiv volumele cu baza de date și fișierele media.
-=======
-  Oprește și elimină containerele și șterge toate datele și fișierele MilDocDMS
-- **6. Mount container MilDocDMS**
+- **5. Alătură sistemul la domeniu**
+  Configurează integrarea în domeniul Active Directory folosind `realm join`.
+- **6. Dezinstalează MilDocDMS**
+  Elimină containerele, volumele și directorul MilDocDMS (dacă există). Curăță orice resurse Docker rămase chiar dacă folderul a fost șters, inclusiv volumele cu baza de date și fișierele media.
+- **7. Mount container MilDocDMS**
   Pornește containerele MilDocDMS folosind `docker compose up -d` (disponibil doar după instalare)
-- **7. Creare super utilizator**  
+- **8. Creare super utilizator**
   Creează un cont de administrator pentru interfața web (disponibil când serviciul rulează)
-- **8. Accesează shell container webserver**  
+- **9. Accesează shell container webserver**
   Deschide un shell în containerul webserver pentru operațiuni avansate
-- **9. Afișează path-ul folderului MilDocDMS**
+- **10. Afișează path-ul folderului MilDocDMS**
   Arată locația instalării MilDocDMS pe sistemul local
-- **10. Instalează și configurează Samba**
-  Permite partajarea folderelor `originals` și `archive` prin rețeaua locală
+- **11. Instalează și configurează Samba și partajează foldere**
+  Permite partajarea folderelor `originals` și `archive` prin rețeaua locală. Opțiunea este disponibilă doar după alăturarea la domeniu.
 
 ## Monitorizare și Logging
 
@@ -80,7 +79,7 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 
 ## Accesare din Windows prin Samba
 
-După rularea opțiunii **10. Instalează și configurează Samba**, directoarele
+După rularea opțiunii **11. Instalează și configurează Samba și partajează foldere**, directoarele
 `originals` și `archive` din MilDocDMS devin disponibile în rețea. Pentru a le
 accesa de pe Windows:
 

--- a/init.sh
+++ b/init.sh
@@ -39,6 +39,13 @@ while true; do
         mildocdms_installed=0
     fi
 
+    # Verifică dacă sistemul este membru al unui domeniu
+    if command -v realm >/dev/null && [ -n "$(realm list 2>/dev/null)" ]; then
+        domain_joined=1
+    else
+        domain_joined=0
+    fi
+
     echo "======================================"
     echo "      Script de instalare MilDocDMS"
     echo "======================================"
@@ -48,20 +55,18 @@ while true; do
     echo "2. Instalează Ollama"
     echo "3. Instalează Docker"
     echo "4. Instalează MilDocDMS"
-    echo "5. Dezinstalează MilDocDMS (docker compose down)"
-    # Opțiunea 6 este disponibilă doar când MilDocDMS este instalat
+    echo "5. Alătură sistemul la domeniu"
+    echo "6. Dezinstalează MilDocDMS (docker compose down)"
+    # Opțiunea 7 este disponibilă doar când MilDocDMS este instalat
     if [ "$mildocdms_installed" -eq 1 ]; then
-=======
-    if [ "$mildocdms_installed" -eq 1 ]; then
-        echo "5. Dezinstalează MilDocDMS (docker compose down)"
-        echo "6. Mount container MilDocDMS (docker compose up -d)"
+        echo "7. Mount container MilDocDMS (docker compose up -d)"
     fi
     if [ "$web_running" -eq 1 ]; then
-        echo "7. Creare super utilizator (createsuperuser)"
-        echo "8. Accesează shell container webserver"
-        echo "9. Afișează path-ul folderului MilDocDMS"
+        echo "8. Creare super utilizator (createsuperuser)"
+        echo "9. Accesează shell container webserver"
+        echo "10. Afișează path-ul folderului MilDocDMS"
     fi
-    echo "10. Instalează și configurează Samba"
+    echo "11. Instalează și configurează Samba și partajează foldere în rețea"
     echo "q. Ieșire"
     echo "--------------------------------------"
     read -p "Alege o opțiune: " opt
@@ -193,6 +198,31 @@ while true; do
             read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             ;;
         5)
+            echo "Alăturare la domeniu..."
+            if ! command -v realm >/dev/null; then
+                echo "Se instalează pachetele necesare pentru domeniu..."
+                apt-get install -y realmd sssd sssd-tools adcli samba-common 2>&1 | tee -a "$LOG_FILE"
+            fi
+            if [ $domain_joined -eq 1 ]; then
+                echo "Sistemul este deja membru al unui domeniu."
+                realm list 2>&1 | tee -a "$LOG_FILE"
+                read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
+                continue
+            fi
+            read -p "Domeniu (exemplu example.com): " domain_name
+            read -p "Utilizator administrativ: " domain_user
+            realm join "$domain_name" -U "$domain_user" 2>&1 | tee -a "$LOG_FILE"
+            join_exit=${PIPESTATUS[0]}
+            if [ $join_exit -eq 0 ]; then
+                echo -e "\033[1;32mSistemul a fost alăturat cu succes domeniului $domain_name.\033[0m"
+                log "Sistem alăturat domeniului $domain_name."
+            else
+                echo -e "\033[1;31mEroare la alăturarea la domeniu.\033[0m"
+                log "Eroare alăturare domeniu."
+            fi
+            read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
+            ;;
+        6)
             echo "Dezinstalare MilDocDMS (docker compose down -v)..."
             if [ -d "$mildocdms_dir" ]; then
                 cd "$mildocdms_dir" || { echo "Nu se poate accesa directorul $mildocdms_dir"; continue; }
@@ -221,22 +251,6 @@ while true; do
                 if [ $rm_exit -eq 0 ]; then
                     echo -e "\033[1;32mMilDocDMS a fost dezinstalat și toate fișierele au fost șterse.\033[0m"
                     log "MilDocDMS și datele au fost șterse."
-=======
-            if [ "$mildocdms_installed" -eq 1 ]; then
-                echo "Dezinstalare MilDocDMS (docker compose down -v)..."
-                cd "$mildocdms_dir" || { echo "Nu se poate accesa directorul $mildocdms_dir"; continue; }
-                docker compose down -v 2>&1 | tee -a "$LOG_FILE"
-                down_exit=${PIPESTATUS[0]}
-                if [ $down_exit -eq 0 ]; then
-                    rm -rf "$mildocdms_dir" 2>&1 | tee -a "$LOG_FILE"
-                    rm_exit=${PIPESTATUS[0]}
-                    if [ $rm_exit -eq 0 ]; then
-                        echo -e "\033[1;32mMilDocDMS a fost dezinstalat și toate fișierele au fost șterse.\033[0m"
-                        log "MilDocDMS și datele au fost șterse."
-                    else
-                        echo -e "\033[1;31mDezinstalarea a reușit, dar nu am putut șterge fișierele.\033[0m"
-                        log "Eroare la ștergerea fișierelor MilDocDMS."
-                    fi
                 else
                     echo -e "\033[1;31mContainerele au fost oprite, dar nu am putut șterge fișierele.\033[0m"
                     log "Eroare la ștergerea fișierelor MilDocDMS."
@@ -247,7 +261,7 @@ while true; do
             fi
             read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             ;;
-        6)
+        7)
             echo "Mount container MilDocDMS (docker compose up -d)..."
             if [ "$mildocdms_installed" -eq 0 ]; then
                 echo "Directorul MilDocDMS nu există. Instalează MilDocDMS mai întâi (opțiunea 4)."
@@ -270,7 +284,7 @@ while true; do
             fi
             read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             ;;
-        7)
+        8)
             if [ "$web_running" -eq 1 ]; then
                 echo "Creare super utilizator (docker compose run --rm webserver createsuperuser)..."
                 if [ -n "$SUDO_USER" ]; then
@@ -289,7 +303,7 @@ while true; do
                 read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             fi
             ;;
-        8)
+        9)
             if [ "$web_running" -eq 1 ]; then
                 echo "Acces container webserver..."
                 container_name=$(docker ps --filter "name=webserver" --format "{{.Names}}" | head -n 1)
@@ -302,7 +316,7 @@ while true; do
                 read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             fi
             ;;
-        9)
+        10)
             if [ "$web_running" -eq 1 ]; then
                 echo "Path-ul folderului MilDocDMS este:"
                 if [ -n "$SUDO_USER" ]; then
@@ -315,8 +329,13 @@ while true; do
                 read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             fi
             ;;
-        10)
-            echo "Instalare și configurare Samba..."
+        11)
+            if [ $domain_joined -eq 0 ]; then
+                echo "Sistemul nu este membru al unui domeniu. Rulați opțiunea 5 înainte."
+                read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
+                continue
+            fi
+            echo "Instalare și configurare Samba și partajare foldere..."
             log "Încep instalarea Samba."
             if ! dpkg -s samba >/dev/null 2>&1; then
                 apt-get install -y samba 2>&1 | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary
- remove leftover merge markers from init.sh
- restore correct uninstall logic
- ensure menu only shows mount option when installed
- add domain join support and require it before Samba setup

## Testing
- `bash -n init.sh`


------
https://chatgpt.com/codex/tasks/task_e_684927d31d1c8324bf9b49940b687376