### PR TITLE
Fix init.sh menu duplication and if logic

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -56,14 +56,9 @@ while true; do
     echo "3. Instalează Docker"
     echo "4. Instalează MilDocDMS"
     echo "5. Alătură sistemul la domeniu"
-    echo "6. Dezinstalează MilDocDMS (docker compose down)"
-    # Opțiunea 7 este disponibilă doar când MilDocDMS este instalat
     if [ "$mildocdms_installed" -eq 1 ]; then
+        echo "6. Dezinstalează MilDocDMS (docker compose down)"
         echo "7. Mount container MilDocDMS (docker compose up -d)"
-    echo "5. Dezinstalează MilDocDMS (docker compose down)"
-    # Opțiunea 6 este disponibilă doar când MilDocDMS este instalat
-    if [ "$mildocdms_installed" -eq 1 ]; then
-        echo "6. Mount container MilDocDMS (docker compose up -d)"
     fi
     if [ "$web_running" -eq 1 ]; then
         echo "8. Creare super utilizator (createsuperuser)"


### PR DESCRIPTION
## Summary
- fix numbering and duplicates in init.sh options menu
- ensure if/fi blocks match

## Testing
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_68492d3210c08324bf29eecd0eb576e6