### PR TITLE
Fix EOF closing tag indentation

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -379,7 +379,7 @@ while true; do
    writable = yes
    guest ok = yes
    read only = no
-    EOF
+EOF
             fi
             systemctl restart smbd 2>&1 | tee -a "$LOG_FILE"
             restart_exit=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- unindent the `EOF` closing tag when adding Samba shares

## Testing
- `dos2unix init.sh`
- `bash -n init.sh`


------
https://chatgpt.com/codex/tasks/task_e_68493091f7dc8324a0d4a1547e8e8490