### PR TITLE
Fix installer directories and docker volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     ports:
       - "80:8000"
     volumes:
-      - data:/usr/src/paperless/data
-      - media:/usr/src/paperless/media
+      - ./data:/usr/src/paperless/data
+      - ./media:/usr/src/paperless/media
       - ./export:/usr/src/paperless/export
       - ./consume:/usr/src/paperless/consume
     env_file: docker-compose.env
@@ -53,7 +53,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  data:
-  media:
   pgdata:
   redisdata:

--- a/init.sh
+++ b/init.sh
@@ -164,6 +164,7 @@ while true; do
             fi
             mildocdms_dir="$user_home/mildocdms"
             mkdir -p "$mildocdms_dir" 2>&1 | tee -a "$LOG_FILE"
+            mkdir -p "$mildocdms_dir/media/documents/originals" "$mildocdms_dir/media/documents/archive" 2>&1 | tee -a "$LOG_FILE"
             cd "$mildocdms_dir" || { echo "Nu se poate accesa directorul $mildocdms_dir"; continue; }
             rm -f docker-compose.env docker-compose.yml 2>&1 | tee -a "$LOG_FILE"
             echo "Se descarcă docker-compose.env..."


### PR DESCRIPTION
## Summary
- update docker-compose.yml to mount host directories for Paperless
- ensure installer creates required media directories before running compose

## Testing
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_68493b9dff0883249eaeecddef23c675