### PR TITLE
Enable domain logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 - **01. Șterge log-uri**
   Șterge (trunchează) fișierul de loguri pentru a începe o nouă sesiune de diagnosticare
 - **02. Alătură sistemul la domeniu**
-  Configurează integrarea în domeniul Active Directory folosind `realm join`.
+  Configurează integrarea în domeniul Active Directory folosind `realm join` și
+  activează autentificarea utilizatorilor de domeniu. Scriptul rulează
+  `realm permit --all` și `pam-auth-update --enable mkhomedir --force` pentru a
+  permite login-ul oricărui cont de domeniu și pentru a crea automat folderele
+  home la prima autentificare. Scriptul acordă de asemenea drepturi sudo
+  membrilor grupului **Domain Admins** și configurează `xrdp` pentru conectări
+  remote cu utilizatori de domeniu.
 
 ### Instalare și Actualizare
 - **1. Actualizează Linux**


### PR DESCRIPTION
## Summary
- enable domain logins after `realm join`
- grant sudo rights to Domain Admins and ensure xrdp works for domain users
- note domain login and xrdp config in README

## Testing
- `shellcheck init.sh`

------
https://chatgpt.com/codex/tasks/task_e_684950e7c7008324b20d93e6b8c62aeb