### PR TITLE
Enable domain logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 - **01. Șterge log-uri**
   Șterge (trunchează) fișierul de loguri pentru a începe o nouă sesiune de diagnosticare
 - **02. Alătură sistemul la domeniu**
-  Configurează integrarea în domeniul Active Directory folosind `realm join`.
+  Configurează integrarea în domeniul Active Directory folosind `realm join` și
+  activează autentificarea utilizatorilor de domeniu. Scriptul rulează
+  `realm permit --all` și `pam-auth-update --enable mkhomedir --force` pentru a
+  permite login-ul oricărui cont de domeniu și pentru a crea automat folderele
+  home la prima autentificare. Scriptul acordă de asemenea drepturi sudo
+  membrilor grupului **Domain Admins** și configurează `xrdp` pentru conectări
+  remote cu utilizatori de domeniu.
+- **03. Configurează acces domeniu și xrdp**
+  Permite autentificarea utilizatorilor de domeniu și configurează accesul
+  remote prin `xrdp` pentru sisteme deja alăturate domeniului
 
 ### Instalare și Actualizare
 - **1. Actualizează Linux**

--- a/init.sh
+++ b/init.sh
@@ -10,6 +10,33 @@ log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE"
 }
 
+# Configurează permisiunile necesare autentificării utilizatorilor de domeniu
+configure_domain_access() {
+    local domain_name="$1"
+    if [ -z "$domain_name" ]; then
+        domain_name=$(realm list 2>/dev/null | awk '/realm-name/ {print $2}' | head -n1)
+        if [ -z "$domain_name" ]; then
+            echo "Nu s-a putut determina numele domeniului."
+            return 1
+        fi
+    fi
+    echo "Se permite autentificarea utilizatorilor de domeniu..."
+    realm permit --all 2>&1 | tee -a "$LOG_FILE"
+    pam-auth-update --enable mkhomedir --force 2>&1 | tee -a "$LOG_FILE"
+    echo "Configurare privilegii pentru grupul 'Domain Admins'..."
+    domain_upper=$(echo "$domain_name" | tr '[:lower:]' '[:upper:]')
+    sudoers_file="/etc/sudoers.d/domain_admins"
+    echo "%${domain_upper}\\\\Domain Admins ALL=(ALL:ALL) ALL" > "$sudoers_file"
+    chmod 440 "$sudoers_file"
+    log "Drepturi sudo acordate grupului Domain Admins."
+    if ! dpkg -l | grep -q xrdp; then
+        echo "Se instalează xrdp pentru conectarea remote..."
+        apt-get install -y xrdp 2>&1 | tee -a "$LOG_FILE"
+    fi
+    echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
+    systemctl restart xrdp 2>&1 | tee -a "$LOG_FILE"
+}
+
 # Verificare drepturi root
 if [[ $EUID -ne 0 ]]; then
     echo "Acest script trebuie rulat ca root!"
@@ -52,6 +79,7 @@ while true; do
     echo "00. Afișează log-uri"
     echo "01. Șterge log-uri"
     echo "02. Alătură sistemul la domeniu"
+    echo "03. Configurează acces domeniu și xrdp"
     echo "1. Actualizează Linux"
     echo "2. Instalează Ollama"
     echo "3. Instalează Docker"
@@ -104,9 +132,18 @@ while true; do
             if [ $join_exit -eq 0 ]; then
                 echo -e "\033[1;32mSistemul a fost alăturat cu succes domeniului $domain_name.\033[0m"
                 log "Sistem alăturat domeniului $domain_name."
+                configure_domain_access "$domain_name"
             else
                 echo -e "\033[1;31mEroare la alăturarea la domeniu.\033[0m"
                 log "Eroare alăturare domeniu."
+            fi
+            read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
+            ;;
+        "03")
+            if [ $domain_joined -eq 0 ]; then
+                echo "Sistemul nu este membru al unui domeniu. Folosește opțiunea 02 pentru alăturare."
+            else
+                configure_domain_access
             fi
             read -n1 -rsp $'\nApasă orice tastă pentru a reveni la meniu...\n'
             ;;


### PR DESCRIPTION
## Summary
- enable domain logins after `realm join`
- grant sudo rights to Domain Admins and ensure xrdp works for domain users
- note domain login and xrdp config in README
- add a standalone option to configure domain access if the machine is already joined

## Testing
- `shellcheck init.sh`

------
https://chatgpt.com/codex/tasks/task_e_684950e7c7008324b20d93e6b8c62aeb