### PR TITLE
Enable domain logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 - **01. Șterge log-uri**
   Șterge (trunchează) fișierul de loguri pentru a începe o nouă sesiune de diagnosticare
 - **02. Alătură sistemul la domeniu**
-  Configurează integrarea în domeniul Active Directory folosind `realm join`.
+  Configurează integrarea în domeniul Active Directory folosind `realm join` și
+  activează autentificarea utilizatorilor de domeniu. Scriptul rulează
+  `realm permit --all` și `pam-auth-update --enable mkhomedir --force` pentru a
+  permite login-ul oricărui cont de domeniu și pentru a crea automat folderele
+  home la prima autentificare. Scriptul acordă de asemenea drepturi sudo
+  membrilor grupului **Domain Admins** și configurează `xrdp` pentru conectări
+  remote cu utilizatori de domeniu. Scriptul adaugă contul `xrdp` în grupul
+  `ssl-cert` și rescrie `/etc/X11/Xwrapper.config` cu `needs_root_rights=yes`
+  pentru a evita ecranul negru la reconectare.
+- **03. Configurează acces domeniu și xrdp**
+  Permite autentificarea utilizatorilor de domeniu și configurează accesul
+  remote prin `xrdp` pentru sisteme deja alăturate domeniului
 
 ### Instalare și Actualizare
 - **1. Actualizează Linux**


### PR DESCRIPTION
## Summary
- enable domain logins after `realm join`
- grant sudo rights to Domain Admins and ensure xrdp works for domain users
- note domain login and xrdp config in README
- add a standalone option to configure domain access if the machine is already joined
- fix xrdp black screen by resetting Xwrapper config

## Testing
- `shellcheck init.sh`

------
https://chatgpt.com/codex/tasks/task_e_684950e7c7008324b20d93e6b8c62aeb