### PR TITLE
Use local docker compose files for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 - Conexiune la internet
 - Pachete necesare:
   ```bash
-  sudo apt install -y wget dos2unix xrdp curl pip
+  sudo apt install -y xrdp curl pip
   ```
 
 ## Instalare și Rulare
 
-1. Descarcă și pregătește scriptul pentru rulare:
+1. Asigură-te că fișierul `init.sh` și directorul `docker` se află în același folder. Apoi rulează scriptul:
    ```bash
-   rm -f init.sh* && wget https://raw.githubusercontent.com/CiubotaruBogdan/dms/main/init.sh && dos2unix init.sh && chmod +x init.sh && sudo ./init.sh
+   chmod +x init.sh
+   sudo ./init.sh
    ```
 
 ## Funcționalități
@@ -37,7 +38,6 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
   `ssl-cert` și rescrie `/etc/X11/Xwrapper.config` cu `needs_root_rights=yes`
   pentru a evita ecranul negru la reconectare.
 - **03. Configurează acces domeniu și xrdp**
-=======
   Permite autentificarea utilizatorilor de domeniu și configurează accesul
   remote prin `xrdp` pentru sisteme deja alăturate domeniului
 
@@ -56,9 +56,9 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 - **4. Instalează MilDocDMS**
   Instalează și configurează MilDocDMS:
   - Creează directorul de lucru în home-ul utilizatorului
-  - Descarcă și configurează fișierele docker-compose
+  - Copiază fișierele docker-compose din directorul local `docker`
   - Pornește containerele necesare
-  - Oferă opțiunea de urmărire log-uri în timp real
+  - Afișează statusul containerelor la final
 
 ### Gestionare Container MilDocDMS
 - **6. Dezinstalează complet MilDocDMS**
@@ -76,7 +76,7 @@ Acest repository conține script-ul `init.sh`, un instrument interactiv de într
 
 - Toate operațiunile sunt înregistrate în `/tmp/script_intretinere.log`
 - Opțiunile de vizualizare (00) și ștergere (01) a logurilor sunt disponibile în meniul principal
-- Pentru containerele active, scriptul oferă urmărirea log-urilor în timp real
+- Pentru containerele active, statusul poate fi verificat cu `docker compose ps`
 
 ## Note de Utilizare
 

--- a/init.sh
+++ b/init.sh
@@ -4,6 +4,7 @@
 # Logurile se vor salva în /tmp/script_intretinere.log
 
 LOG_FILE="/tmp/script_intretinere.log"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Funcție pentru logare
 log() {
@@ -232,18 +233,18 @@ while true; do
             mkdir -p "$mildocdms_dir/media/documents/originals" "$mildocdms_dir/media/documents/archive" 2>&1 | tee -a "$LOG_FILE"
             cd "$mildocdms_dir" || { echo "Nu se poate accesa directorul $mildocdms_dir"; continue; }
             rm -f docker-compose.env docker-compose.yml 2>&1 | tee -a "$LOG_FILE"
-            echo "Se descarcă docker-compose.env..."
-            wget -O docker-compose.env https://raw.githubusercontent.com/CiubotaruBogdan/dms/main/docker/docker-compose.env 2>&1 | tee -a "$LOG_FILE"
+            echo "Se copiază docker-compose.env din folderul local..."
+            cp "$SCRIPT_DIR/docker/docker-compose.env" docker-compose.env 2>&1 | tee -a "$LOG_FILE"
             env_exit=${PIPESTATUS[0]}
             if [ $env_exit -ne 0 ]; then
-                echo -e "\033[1;31mEroare la descărcarea docker-compose.env.\033[0m"
+                echo -e "\033[1;31mEroare la copierea docker-compose.env.\033[0m"
                 continue
             fi
-            echo "Se descarcă docker-compose.yml..."
-            wget -O docker-compose.yml https://raw.githubusercontent.com/CiubotaruBogdan/dms/main/docker/docker-compose.yml 2>&1 | tee -a "$LOG_FILE"
+            echo "Se copiază docker-compose.yml din folderul local..."
+            cp "$SCRIPT_DIR/docker/docker-compose.yml" docker-compose.yml 2>&1 | tee -a "$LOG_FILE"
             yml_exit=${PIPESTATUS[0]}
             if [ $yml_exit -ne 0 ]; then
-                echo -e "\033[1;31mEroare la descărcarea docker-compose.yml.\033[0m"
+                echo -e "\033[1;31mEroare la copierea docker-compose.yml.\033[0m"
                 continue
             fi
             echo "Pornește MilDocDMS cu docker compose up -d..."
@@ -254,8 +255,6 @@ while true; do
                 log "MilDocDMS instalat cu succes."
                 echo -e "\nStatusul containerelor MilDocDMS:"
                 docker compose ps 2>&1 | tee -a "$LOG_FILE"
-                echo -e "\n--- Urmărirea log-urilor în timp real ---"
-                docker compose logs --follow --tail=100
             else
                 echo -e "\033[1;31mEroare la instalarea MilDocDMS.\033[0m"
                 log "Eroare la instalarea MilDocDMS."
@@ -316,8 +315,6 @@ while true; do
                 log "Container MilDocDMS montat cu succes."
                 echo -e "\nStatusul containerelor MilDocDMS:"
                 docker compose ps 2>&1 | tee -a "$LOG_FILE"
-                echo -e "\n--- Urmărirea log-urilor în timp real ---"
-                docker compose logs --follow --tail=100
             else
                 echo -e "\033[1;31mEroare la montarea containerului MilDocDMS.\033[0m"
                 log "Eroare la montarea containerului MilDocDMS."


### PR DESCRIPTION
## Summary
- Copy docker-compose files from local docker directory instead of downloading
- Reference script location to access bundled compose files
- Show MilDocDMS install success and container status before returning to menu

## Testing
- `bash -n init.sh`
- `shellcheck init.sh` *(fails: command not found; apt repository 403)*


------
https://chatgpt.com/codex/tasks/task_b_68a80512f80483298e9ce3d8e0b9f8b4